### PR TITLE
fix: Parse variables in config fields

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -16,11 +16,11 @@ More infos available on the LTN website: https://ltnglobal.com/
 To get a pair of credentials for the Schedule API, create a new user in the Schedule UI and assign
 the api user role to it. You can then use it to connect through this companion module.
 
-| Setting          | Description                                                     |
-|------------------|-----------------------------------------------------------------|
-| **Host**         | Enter the hostname of your Schedule instance.                   |
-| **API Username** | Enter the username of one of the Schedule instance's API Users. |
-| **API Password** | Enter the corresponding password.                               |
+| Setting          | Description                                                                         |
+|------------------|-------------------------------------------------------------------------------------|
+| **Host**         | Enter the hostname of your Schedule instance. (Can be a variable)                   |
+| **API Username** | Enter the username of one of the Schedule instance's API Users. (Can be a variable) |
+| **API Password** | Enter the corresponding password. (Can be a variable)                               |
 
 ## Actions
 

--- a/index.js
+++ b/index.js
@@ -82,9 +82,9 @@ class LTNScheduleInstance extends InstanceBase {
 	async init(config) {
 		this.config = config
 
-		this.config.host = config.host || ''
-		this.config.username = config.username
-		this.config.password = config.password
+		this.config.host = await this.parseVariablesInString(config.host) || ''
+		this.config.username = await this.parseVariablesInString(config.username)
+		this.config.password = await this.parseVariablesInString(config.password)
 
 		if (this.config.host === '') {
 			this.updateStatus('bad_config', 'Configuration required')
@@ -104,7 +104,12 @@ class LTNScheduleInstance extends InstanceBase {
 
 	// New config saved
 	async configUpdated(config) {
+
 		this.config = config
+		this.config.host = await this.parseVariablesInString(config.host) || ''
+		this.config.username = await this.parseVariablesInString(config.username)
+		this.config.password = await this.parseVariablesInString(config.password)
+
 		initAPI.bind(this)()
 		this.actions()
 		this.init_feedbacks()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ltn-schedule",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Allow using variables in config field